### PR TITLE
Allow to cross-compile the library with Mingw-w64

### DIFF
--- a/Codec/config.h
+++ b/Codec/config.h
@@ -38,7 +38,7 @@
 
 // Enable use of assembly language for code optimization
 #ifndef _ASMOPT
-#ifdef __LP64__
+#if defined(__LP64__) || defined(__GNUC__)
 #define _ASMOPT 0
 #else
 #ifndef _WIN64

--- a/Codec/convert.c
+++ b/Codec/convert.c
@@ -66,7 +66,7 @@ int Timecode2frames(char *tc, int rate)
 
     if (tc)
     {
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__GNUC__)
         ret = sscanf_s(tc, "%02d:%02d:%02d:%02d", &hr, &mn, &sc, &fr);
 #else
         ret = sscanf(tc, "%02d:%02d:%02d:%02d", &hr, &mn, &sc, &fr);

--- a/EncoderSDK/MetadataWriter.cpp
+++ b/EncoderSDK/MetadataWriter.cpp
@@ -256,7 +256,7 @@ uint32_t ValidateLookGenCRCEnc(char *path)
                         hexstring[7] = buf[pos + 1];
 
                         //printf("%s",hexstring);
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__GNUC__)
                         sscanf_s(hexstring, "%08x", (int *)&val);
 #else
                         sscanf(hexstring, "%08x", (int *)&val);


### PR DESCRIPTION
Update some #ifdef conditions that assume MSVC-specific behavior when target platform is Windows.

These changes fix errors about sscanf_s not being available when cross-compiling the library on Ubuntu 16.04 with mingw-w64 installed. It also disables some inline assembly because the "__asm" syntax is not compatible with GCC.